### PR TITLE
Fix appstream metadata

### DIFF
--- a/assamese/io.pagure.lohit.assamese.font.metainfo.xml
+++ b/assamese/io.pagure.lohit.assamese.font.metainfo.xml
@@ -17,9 +17,9 @@
   </description>
   <url type="homepage">https://pagure.io/lohit</url>
   <url type="bugtracker">https://github.com/pravins/lohit/issues</url>
-  <updatecontact>psatpute_at_redhat_dot_com</updatecontact>
+  <update_contact>psatpute_at_redhat_dot_com</update_contact>
   <provides>
-	  <font>Lohit Assamese Regular</font>
+	  <font>Lohit Assamese</font>
   </provides>
   <languages>
 	  <lang>as</lang>

--- a/bengali/io.pagure.lohit.bengali.font.metainfo.xml
+++ b/bengali/io.pagure.lohit.bengali.font.metainfo.xml
@@ -17,9 +17,9 @@
   </description>
   <url type="homepage">https://pagure.io/lohit</url>
   <url type="bugtracker">https://github.com/pravins/lohit/issues</url>
-  <updatecontact>psatpute_at_redhat_dot_com</updatecontact>
+  <update_contact>psatpute_at_redhat_dot_com</update_contact>
   <provides>
-	  <font>Lohit Bengali Regular</font>
+	  <font>Lohit Bengali</font>
   </provides>
   <languages>
 	  <lang>bn</lang>

--- a/devanagari/io.pagure.lohit.devanagari.font.metainfo.xml
+++ b/devanagari/io.pagure.lohit.devanagari.font.metainfo.xml
@@ -17,9 +17,9 @@
   </description>
   <url type="homepage">https://pagure.io/lohit</url>
   <url type="bugtracker">https://github.com/pravins/lohit/issues</url>
-  <updatecontact>psatpute_at_redhat_dot_com</updatecontact>
+  <update_contact>psatpute_at_redhat_dot_com</update_contact>
   <provides>
-	  <font>Lohit Devanagari Regular</font>
+	  <font>Lohit Devanagari</font>
   </provides>
   <languages>
 	  <lang>hi</lang>

--- a/gujarati/io.pagure.lohit.gujarati.font.metainfo.xml
+++ b/gujarati/io.pagure.lohit.gujarati.font.metainfo.xml
@@ -17,9 +17,9 @@
   </description>
   <url type="homepage">https://pagure.io/lohit</url>
   <url type="bugtracker">https://github.com/pravins/lohit/issues</url>
-  <updatecontact>psatpute_at_redhat_dot_com</updatecontact>
+  <update_contact>psatpute_at_redhat_dot_com</update_contact>
   <provides>
-	  <font>Lohit Gujarati Regular</font>
+	  <font>Lohit Gujarati</font>
   </provides>
   <languages>
 	  <lang>gu</lang>

--- a/gurmukhi/io.pagure.lohit.gurmukhi.font.metainfo.xml
+++ b/gurmukhi/io.pagure.lohit.gurmukhi.font.metainfo.xml
@@ -17,9 +17,9 @@
   </description>
   <url type="homepage">https://pagure.io/lohit</url>
   <url type="bugtracker">https://github.com/pravins/lohit/issues</url>
-  <updatecontact>psatpute_at_redhat_dot_com</updatecontact>
+  <update_contact>psatpute_at_redhat_dot_com</update_contact>
   <provides>
-	  <font>Lohit Gurmukhi Regular</font>
+	  <font>Lohit Gurmukhi</font>
   </provides>
   <languages>
 	  <lang>pa</lang>

--- a/kannada/io.pagure.lohit.kannada.font.metainfo.xml
+++ b/kannada/io.pagure.lohit.kannada.font.metainfo.xml
@@ -17,9 +17,9 @@
   </description>
   <url type="homepage">https://pagure.io/lohit</url>
   <url type="bugtracker">https://github.com/pravins/lohit/issues</url>
-  <updatecontact>psatpute_at_redhat_dot_com</updatecontact>
+  <update_contact>psatpute_at_redhat_dot_com</update_contact>
   <provides>
-	  <font>Lohit Kannada Regular</font>
+	  <font>Lohit Kannada</font>
   </provides>
   <languages>
 	  <lang>kn</lang>

--- a/malayalam/io.pagure.lohit.malayalam.font.metainfo.xml
+++ b/malayalam/io.pagure.lohit.malayalam.font.metainfo.xml
@@ -17,9 +17,9 @@
   </description>
   <url type="homepage">https://pagure.io/lohit</url>
   <url type="bugtracker">https://github.com/pravins/lohit/issues</url>
-  <updatecontact>psatpute_at_redhat_dot_com</updatecontact>
+  <update_contact>psatpute_at_redhat_dot_com</update_contact>
   <provides>
-	  <font>Lohit Malayalam Regular</font>
+	  <font>Lohit Malayalam</font>
   </provides>
   <languages>
 	  <lang>ml</lang>

--- a/marathi/io.pagure.lohit.marathi.font.metainfo.xml
+++ b/marathi/io.pagure.lohit.marathi.font.metainfo.xml
@@ -17,9 +17,9 @@
   </description>
   <url type="homepage">https://pagure.io/lohit</url>
   <url type="bugtracker">https://github.com/pravins/lohit/issues</url>
-  <updatecontact>psatpute_at_redhat_dot_com</updatecontact>
+  <update_contact>psatpute_at_redhat_dot_com</update_contact>
   <provides>
-	  <font>Lohit Marathi Regular</font>
+	  <font>Lohit Marathi</font>
   </provides>
   <languages>
 	  <lang>mr</lang>

--- a/nepali/io.pagure.lohit.nepali.font.metainfo.xml
+++ b/nepali/io.pagure.lohit.nepali.font.metainfo.xml
@@ -17,9 +17,9 @@
   </description>
   <url type="homepage">https://pagure.io/lohit</url>
   <url type="bugtracker">https://github.com/pravins/lohit/issues</url>
-  <updatecontact>psatpute_at_redhat_dot_com</updatecontact>
+  <update_contact>psatpute_at_redhat_dot_com</update_contact>
   <provides>
-	  <font>Lohit Nepali Regular</font>
+	  <font>Lohit Nepali</font>
   </provides>
   <languages>
 	  <lang>ne</lang>

--- a/odia/io.pagure.lohit.odia.font.metainfo.xml
+++ b/odia/io.pagure.lohit.odia.font.metainfo.xml
@@ -17,9 +17,9 @@
   </description>
   <url type="homepage">https://pagure.io/lohit</url>
   <url type="bugtracker">https://github.com/pravins/lohit/issues</url>
-  <updatecontact>psatpute_at_redhat_dot_com</updatecontact>
+  <update_contact>psatpute_at_redhat_dot_com</update_contact>
   <provides>
-	  <font>Lohit Odia Regular</font>
+	  <font>Lohit Odia</font>
   </provides>
   <languages>
 	  <lang>or</lang>

--- a/tamil-classical/io.pagure.lohit.tamil.classical.font.metainfo.xml
+++ b/tamil-classical/io.pagure.lohit.tamil.classical.font.metainfo.xml
@@ -17,9 +17,9 @@
   </description>
   <url type="homepage">https://pagure.io/lohit</url>
   <url type="bugtracker">https://github.com/pravins/lohit/issues</url>
-  <updatecontact>psatpute_at_redhat_dot_com</updatecontact>
+  <update_contact>psatpute_at_redhat_dot_com</update_contact>
   <provides>
-	  <font>Lohit Tamil Classical Regular</font>
+	  <font>Lohit Tamil Classical</font>
   </provides>
   <languages>
 	  <lang>ta</lang>

--- a/tamil/io.pagure.lohit.tamil.font.metainfo.xml
+++ b/tamil/io.pagure.lohit.tamil.font.metainfo.xml
@@ -17,9 +17,9 @@
   </description>
   <url type="homepage">https://pagure.io/lohit</url>
   <url type="bugtracker">https://github.com/pravins/lohit/issues</url>
-  <updatecontact>psatpute_at_redhat_dot_com</updatecontact>
+  <update_contact>psatpute_at_redhat_dot_com</update_contact>
   <provides>
-	  <font>Lohit Tamil Regular</font>
+	  <font>Lohit Tamil</font>
   </provides>
   <languages>
 	  <lang>ta</lang>

--- a/telugu/io.pagure.lohit.telugu.font.metainfo.xml
+++ b/telugu/io.pagure.lohit.telugu.font.metainfo.xml
@@ -17,9 +17,9 @@
   </description>
   <url type="homepage">https://pagure.io/lohit</url>
   <url type="bugtracker">https://github.com/pravins/lohit/issues</url>
-  <updatecontact>psatpute_at_redhat_dot_com</updatecontact>
+  <update_contact>psatpute_at_redhat_dot_com</update_contact>
   <provides>
-	  <font>Lohit Telugu Regular</font>
+	  <font>Lohit Telugu</font>
   </provides>
   <languages>
 	  <lang>te</lang>


### PR DESCRIPTION
The provided font name must match the font's "fullname" as seen by fc-query

I verified that the appstream metadata now works correctly after this patch for Lohit Assamese.

I think you can go ahead and close #82 after merging this.